### PR TITLE
SCRUM-11-회원-엑셀-도메인-구현

### DIFF
--- a/.github/workflows/CICI.yml
+++ b/.github/workflows/CICI.yml
@@ -17,6 +17,10 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DB }}
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
 
     steps:
       - uses: actions/checkout@v3

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
     //mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    //Thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    //mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ dependencies {
 
     //Thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    //poi
+    implementation 'org.apache.poi:poi:5.2.5'
+    implementation 'org.apache.poi:poi-ooxml:5.2.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/donttouchme/DontTouchMeApplication.java
+++ b/src/main/java/com/example/donttouchme/DontTouchMeApplication.java
@@ -3,9 +3,11 @@ package com.example.donttouchme;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync
 public class DontTouchMeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/donttouchme/common/OAuth2/dto/CustomUser.java
+++ b/src/main/java/com/example/donttouchme/common/OAuth2/dto/CustomUser.java
@@ -50,4 +50,7 @@ public class CustomUser implements OAuth2User, UserDetails {
     public Long getMemberId() {
         return member.getId();
     }
+    public String getEmail() {
+        return member.getEmail();
+    }
 }

--- a/src/main/java/com/example/donttouchme/common/config/AsyncConfig.java
+++ b/src/main/java/com/example/donttouchme/common/config/AsyncConfig.java
@@ -1,0 +1,20 @@
+package com.example.donttouchme.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "mailTaskExecutor")
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5); // 기본 스레드 수
+        executor.setMaxPoolSize(10); // 최대 스레드 수
+        executor.setQueueCapacity(100); // 대기 큐 크기
+        executor.setThreadNamePrefix("Mail-Async-"); // 스레드 이름 접두사
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/example/donttouchme/common/config/MailConfig.java
+++ b/src/main/java/com/example/donttouchme/common/config/MailConfig.java
@@ -1,0 +1,71 @@
+package com.example.donttouchme.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender getJavaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls-enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/com/example/donttouchme/common/config/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/example/donttouchme/common/config/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,34 @@
+package com.example.donttouchme.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    /**
+     * "Content-Type: multipart/form-data" 헤더를 지원하는 HTTP 요청 변환기
+     */
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/example/donttouchme/common/config/RedisConfig.java
+++ b/src/main/java/com/example/donttouchme/common/config/RedisConfig.java
@@ -5,7 +5,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories
@@ -18,6 +20,15 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
     }
 
 }

--- a/src/main/java/com/example/donttouchme/common/config/WebConfig.java
+++ b/src/main/java/com/example/donttouchme/common/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.example.donttouchme.common.config;
+
+import com.example.donttouchme.common.config.security.AuthMemberArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AuthMemberArgumentResolver());
+    }
+}

--- a/src/main/java/com/example/donttouchme/common/config/security/AuthMember.java
+++ b/src/main/java/com/example/donttouchme/common/config/security/AuthMember.java
@@ -1,0 +1,11 @@
+package com.example.donttouchme.common.config.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMember {
+}

--- a/src/main/java/com/example/donttouchme/common/config/security/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/example/donttouchme/common/config/security/AuthMemberArgumentResolver.java
@@ -1,0 +1,52 @@
+package com.example.donttouchme.common.config.security;
+
+import com.example.donttouchme.common.OAuth2.dto.CustomUser;
+import com.example.donttouchme.common.config.security.dto.AuthMemberDto;
+import com.example.donttouchme.member.service.security.CustomUserDetails;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            final MethodParameter parameter,
+            final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest,
+            final WebDataBinderFactory binderFactory
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new IllegalStateException("인증되지 않은 사용자입니다.");
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        // OAuth2 로그인 처리 (CustomUser)
+        if (principal instanceof CustomUser) {
+            CustomUser customUser = (CustomUser) principal;
+            String role = authentication.getAuthorities().iterator().next().getAuthority();
+            return new AuthMemberDto(customUser.getMemberId(), customUser.getEmail(), role);
+        }
+
+        // JWT 로그인 처리 (CustomUserDetails)
+        else if (principal instanceof CustomUserDetails) {
+            CustomUserDetails customUserDetails = (CustomUserDetails) principal;
+            String role = authentication.getAuthorities().iterator().next().getAuthority();
+            return new AuthMemberDto(customUserDetails.getUserId(), customUserDetails.getUsername(), role);
+        }
+
+        throw new IllegalStateException("지원하지 않는 인증 유형입니다.");
+    }
+}

--- a/src/main/java/com/example/donttouchme/common/config/security/dto/AuthMemberDto.java
+++ b/src/main/java/com/example/donttouchme/common/config/security/dto/AuthMemberDto.java
@@ -1,0 +1,12 @@
+package com.example.donttouchme.common.config.security.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class AuthMemberDto {
+    private final Long userId;
+    private final String email; // 또는 username
+    private final String role;
+}

--- a/src/main/java/com/example/donttouchme/event/domain/Event.java
+++ b/src/main/java/com/example/donttouchme/event/domain/Event.java
@@ -6,6 +6,7 @@ import com.example.donttouchme.event.domain.value.Location;
 import com.example.donttouchme.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -50,4 +51,15 @@ public class Event extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Builder
+    public Event(String eventName, String eventType, LocalDate eventDate, Location location, EventInfo eventInfo, Integer participants, Member member) {
+        this.eventName = eventName;
+        this.eventType = eventType;
+        this.eventDate = eventDate;
+        this.location = location;
+        this.eventInfo = eventInfo;
+        this.participants = participants;
+        this.member = member;
+    }
 }

--- a/src/main/java/com/example/donttouchme/event/domain/EventDetail.java
+++ b/src/main/java/com/example/donttouchme/event/domain/EventDetail.java
@@ -3,6 +3,7 @@ package com.example.donttouchme.event.domain;
 import com.example.donttouchme.common.Entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -51,4 +52,16 @@ public class EventDetail extends BaseEntity {
 
     @OneToMany(mappedBy = "eventDetail", cascade = CascadeType.ALL)
     private final List<Tag> tags = new ArrayList<>();
+
+    @Builder
+    public EventDetail(String type, String history, String price, String name, String image, Event event, Target target, SendValue sendValue) {
+        this.type = type;
+        this.history = history;
+        this.price = price;
+        this.name = name;
+        this.image = image;
+        this.event = event;
+        this.target = target;
+        this.sendValue = sendValue;
+    }
 }

--- a/src/main/java/com/example/donttouchme/event/domain/SendValue.java
+++ b/src/main/java/com/example/donttouchme/event/domain/SendValue.java
@@ -1,5 +1,6 @@
 package com.example.donttouchme.event.domain;
 
+import com.example.donttouchme.common.Entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
-public class SendValue {
+public class SendValue extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/example/donttouchme/event/domain/SendValue.java
+++ b/src/main/java/com/example/donttouchme/event/domain/SendValue.java
@@ -3,6 +3,7 @@ package com.example.donttouchme.event.domain;
 import com.example.donttouchme.common.Entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -20,4 +21,9 @@ public class SendValue extends BaseEntity {
 
     @Column(nullable = false)
     private String value;
+
+    @Builder
+    public SendValue(String value) {
+        this.value = value;
+    }
 }

--- a/src/main/java/com/example/donttouchme/event/domain/Tag.java
+++ b/src/main/java/com/example/donttouchme/event/domain/Tag.java
@@ -3,6 +3,7 @@ package com.example.donttouchme.event.domain;
 import com.example.donttouchme.common.Entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -25,4 +26,10 @@ public class Tag extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_detail_id")
     private EventDetail eventDetail;
+
+    @Builder
+    public Tag(String value, EventDetail eventDetail) {
+        this.value = value;
+        this.eventDetail = eventDetail;
+    }
 }

--- a/src/main/java/com/example/donttouchme/event/domain/Target.java
+++ b/src/main/java/com/example/donttouchme/event/domain/Target.java
@@ -3,6 +3,7 @@ package com.example.donttouchme.event.domain;
 import com.example.donttouchme.common.Entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -22,4 +23,8 @@ public class Target extends BaseEntity {
     @Column(nullable = false)
     private String value;
 
+    @Builder
+    public Target(String value) {
+        this.value = value;
+    }
 }

--- a/src/main/java/com/example/donttouchme/event/domain/value/EventInfo.java
+++ b/src/main/java/com/example/donttouchme/event/domain/value/EventInfo.java
@@ -6,6 +6,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,5 +37,16 @@ public class EventInfo {
 
     @Column(nullable = false)
     private boolean isSend;
+
+    public List<String> toCellValues() {
+        List<String> cellValues = new ArrayList<>();
+        if (isType) cellValues.add("입출금 분류");
+        if (isHistory) cellValues.add("입출금 내역명");
+        if (isPrice) cellValues.add("금액");
+        if (isName) cellValues.add("이름");
+        if (isTag) cellValues.add("태그");
+        if (isSide) cellValues.add("입금대상");
+        return cellValues;
+    }
 
 }

--- a/src/main/java/com/example/donttouchme/event/domain/value/EventInfo.java
+++ b/src/main/java/com/example/donttouchme/event/domain/value/EventInfo.java
@@ -3,6 +3,7 @@ package com.example.donttouchme.event.domain.value;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,6 +38,27 @@ public class EventInfo {
 
     @Column(nullable = false)
     private boolean isSend;
+
+    @Builder
+    public EventInfo(
+            final boolean isType,
+            final boolean isHistory,
+            final boolean isPrice,
+            final boolean isName,
+            final boolean isTag,
+            final boolean isImage,
+            final boolean isSide,
+            final boolean isSend
+    ) {
+        this.isType = isType;
+        this.isHistory = isHistory;
+        this.isPrice = isPrice;
+        this.isName = isName;
+        this.isTag = isTag;
+        this.isImage = isImage;
+        this.isSide = isSide;
+        this.isSend = isSend;
+    }
 
     public List<String> toCellValues() {
         List<String> cellValues = new ArrayList<>();

--- a/src/main/java/com/example/donttouchme/event/domain/value/Location.java
+++ b/src/main/java/com/example/donttouchme/event/domain/value/Location.java
@@ -3,6 +3,7 @@ package com.example.donttouchme.event.domain.value;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,4 +22,11 @@ public class Location {
 
     @Column(nullable = false)
     private String address;
+
+    @Builder
+    public Location(BigDecimal latitude, BigDecimal longitude, String address) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.address = address;
+    }
 }

--- a/src/main/java/com/example/donttouchme/event/repository/EventDetailRepository.java
+++ b/src/main/java/com/example/donttouchme/event/repository/EventDetailRepository.java
@@ -1,0 +1,7 @@
+package com.example.donttouchme.event.repository;
+
+import com.example.donttouchme.event.domain.EventDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventDetailRepository extends JpaRepository<EventDetail,Long> {
+}

--- a/src/main/java/com/example/donttouchme/event/repository/EventRepository.java
+++ b/src/main/java/com/example/donttouchme/event/repository/EventRepository.java
@@ -1,7 +1,18 @@
 package com.example.donttouchme.event.repository;
 
 import com.example.donttouchme.event.domain.Event;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
+    @Query("SELECT e FROM Event e " +
+            "LEFT JOIN FETCH e.eventDetails ed " +
+            "LEFT JOIN FETCH ed.target " +
+            "LEFT JOIN FETCH ed.sendValue " +
+            "LEFT JOIN FETCH ed.tags " +
+            "WHERE e.id = :eventId AND e.deletedAt IS NULL")
+    Optional<Event> findByIdWithDetails(@Param("eventId") Long eventId);
 }

--- a/src/main/java/com/example/donttouchme/event/repository/EventRepository.java
+++ b/src/main/java/com/example/donttouchme/event/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package com.example.donttouchme.event.repository;
+
+import com.example.donttouchme.event.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/example/donttouchme/event/repository/TagRepository.java
+++ b/src/main/java/com/example/donttouchme/event/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package com.example.donttouchme.event.repository;
+
+import com.example.donttouchme.event.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/com/example/donttouchme/event/repository/TargetRepository.java
+++ b/src/main/java/com/example/donttouchme/event/repository/TargetRepository.java
@@ -1,0 +1,7 @@
+package com.example.donttouchme.event.repository;
+
+import com.example.donttouchme.event.domain.Target;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TargetRepository extends JpaRepository<Target, Long> {
+}

--- a/src/main/java/com/example/donttouchme/excel/controller/ExcelController.java
+++ b/src/main/java/com/example/donttouchme/excel/controller/ExcelController.java
@@ -1,0 +1,40 @@
+package com.example.donttouchme.excel.controller;
+
+import com.example.donttouchme.excel.service.ExcelQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@RestController
+@RequestMapping("/api/v1/excel")
+@RequiredArgsConstructor
+public class ExcelController implements ExcelControllerSagger {
+
+    private final ExcelQueryService excelQueryService;
+
+    @Override
+    @GetMapping("/download")
+    public ResponseEntity<byte[]> exportSampleExcel(
+            @RequestParam final Long eventId
+    ){
+        byte[] excelByte = excelQueryService.exportSampleExcel(eventId);
+
+        String fileName = "event_form.xlsx";
+
+        HttpHeaders headers = new HttpHeaders();
+        // 파일 이름 인코딩 처리
+        String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8).replace("+", "%20");
+        headers.add("Content-Disposition", "attachment; filename*=UTF-8''" + encodedFileName);
+        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+
+        return ResponseEntity.ok().headers(headers).body(excelByte);
+    }
+}

--- a/src/main/java/com/example/donttouchme/excel/controller/ExcelController.java
+++ b/src/main/java/com/example/donttouchme/excel/controller/ExcelController.java
@@ -27,14 +27,29 @@ public class ExcelController implements ExcelControllerSagger {
     ){
         byte[] excelByte = excelQueryService.exportSampleExcel(eventId);
 
-        String fileName = "event_form.xlsx";
+        HttpHeaders headers = setHeader("event_form.xlsx");
 
+        return ResponseEntity.ok().headers(headers).body(excelByte);
+    }
+
+    @Override
+    @GetMapping()
+    public ResponseEntity<byte[]> exportEventToExcel(
+            @RequestParam final Long eventId) {
+        byte[] excelByte = excelQueryService.exportEventToExcel(eventId);
+
+        HttpHeaders headers = setHeader("event.xlsx");
+
+        return ResponseEntity.ok().headers(headers).body(excelByte);
+    }
+
+    private HttpHeaders setHeader(final String fileName) {
         HttpHeaders headers = new HttpHeaders();
-        // 파일 이름 인코딩 처리
+
         String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8).replace("+", "%20");
         headers.add("Content-Disposition", "attachment; filename*=UTF-8''" + encodedFileName);
         headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
 
-        return ResponseEntity.ok().headers(headers).body(excelByte);
+        return headers;
     }
 }

--- a/src/main/java/com/example/donttouchme/excel/controller/ExcelController.java
+++ b/src/main/java/com/example/donttouchme/excel/controller/ExcelController.java
@@ -1,15 +1,17 @@
 package com.example.donttouchme.excel.controller;
 
+import com.example.donttouchme.excel.controller.dto.ImportExcelRequest;
+import com.example.donttouchme.excel.controller.dto.ImportExcelResponse;
+import com.example.donttouchme.excel.service.ExcelCommandService;
 import com.example.donttouchme.excel.service.ExcelQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
@@ -19,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 public class ExcelController implements ExcelControllerSagger {
 
     private final ExcelQueryService excelQueryService;
+    private final ExcelCommandService excelCommandService;
 
     @Override
     @GetMapping("/download")
@@ -33,7 +36,7 @@ public class ExcelController implements ExcelControllerSagger {
     }
 
     @Override
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<byte[]> exportEventToExcel(
             @RequestParam final Long eventId) {
         byte[] excelByte = excelQueryService.exportEventToExcel(eventId);
@@ -52,4 +55,13 @@ public class ExcelController implements ExcelControllerSagger {
 
         return headers;
     }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ImportExcelResponse> importExcel(
+            @RequestPart(value = "importExcelRequest") final ImportExcelRequest importExcelRequest,
+            @RequestPart(value = "file") final MultipartFile file
+    ) throws IOException {
+        return ResponseEntity.ok(excelCommandService.importEventDetailsFromExcel(importExcelRequest.eventId(), file.getBytes()));
+    }
+
 }

--- a/src/main/java/com/example/donttouchme/excel/controller/ExcelControllerSagger.java
+++ b/src/main/java/com/example/donttouchme/excel/controller/ExcelControllerSagger.java
@@ -1,0 +1,17 @@
+package com.example.donttouchme.excel.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "excel 관련 API", description = "excel 관련 API 입니다.")
+public interface ExcelControllerSagger {
+
+    @Operation(
+            summary = "엑셀 양식 다운로드 API",
+            description = "엑셀 양식을 다운로드 합니다."
+    )
+    ResponseEntity<byte[]> exportSampleExcel(
+            Long eventId
+    );
+}

--- a/src/main/java/com/example/donttouchme/excel/controller/ExcelControllerSagger.java
+++ b/src/main/java/com/example/donttouchme/excel/controller/ExcelControllerSagger.java
@@ -14,4 +14,12 @@ public interface ExcelControllerSagger {
     ResponseEntity<byte[]> exportSampleExcel(
             Long eventId
     );
+
+    @Operation(
+            summary = "이벤트 엑셀 추출 API",
+            description = "이벤트를 엑셀로 추출해줌"
+    )
+    ResponseEntity<byte[]> exportEventToExcel(
+            Long eventId
+    );
 }

--- a/src/main/java/com/example/donttouchme/excel/controller/ExcelControllerSagger.java
+++ b/src/main/java/com/example/donttouchme/excel/controller/ExcelControllerSagger.java
@@ -1,8 +1,13 @@
 package com.example.donttouchme.excel.controller;
 
+import com.example.donttouchme.excel.controller.dto.ImportExcelRequest;
+import com.example.donttouchme.excel.controller.dto.ImportExcelResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(name = "excel 관련 API", description = "excel 관련 API 입니다.")
 public interface ExcelControllerSagger {
@@ -22,4 +27,13 @@ public interface ExcelControllerSagger {
     ResponseEntity<byte[]> exportEventToExcel(
             Long eventId
     );
+
+    @Operation(
+            summary = "엑셀로 import API",
+            description = "엑셀로 import 합니다."
+    )
+    ResponseEntity<ImportExcelResponse> importExcel(
+            ImportExcelRequest importExcelRequest,
+            MultipartFile file
+    ) throws IOException;
 }

--- a/src/main/java/com/example/donttouchme/excel/controller/dto/ImportExcelRequest.java
+++ b/src/main/java/com/example/donttouchme/excel/controller/dto/ImportExcelRequest.java
@@ -1,0 +1,9 @@
+package com.example.donttouchme.excel.controller.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record ImportExcelRequest(
+        @NotEmpty(message = "eventId는 필수입니다.")
+        Long eventId
+) {
+}

--- a/src/main/java/com/example/donttouchme/excel/controller/dto/ImportExcelResponse.java
+++ b/src/main/java/com/example/donttouchme/excel/controller/dto/ImportExcelResponse.java
@@ -1,0 +1,15 @@
+package com.example.donttouchme.excel.controller.dto;
+
+import com.example.donttouchme.event.domain.EventDetail;
+
+import java.util.List;
+
+public record ImportExcelResponse(
+        List<Long> eventDetailIds
+) {
+        public static ImportExcelResponse of(List<EventDetail> eventDetails) {
+            return new ImportExcelResponse(
+                    eventDetails.stream().map(EventDetail::getId).toList()
+            );
+        }
+}

--- a/src/main/java/com/example/donttouchme/excel/service/ExcelCommandService.java
+++ b/src/main/java/com/example/donttouchme/excel/service/ExcelCommandService.java
@@ -1,0 +1,144 @@
+package com.example.donttouchme.excel.service;
+
+import com.example.donttouchme.event.domain.Event;
+import com.example.donttouchme.event.domain.EventDetail;
+import com.example.donttouchme.event.domain.Tag;
+import com.example.donttouchme.event.domain.Target;
+import com.example.donttouchme.event.domain.value.EventInfo;
+import com.example.donttouchme.event.repository.EventDetailRepository;
+import com.example.donttouchme.event.repository.EventRepository;
+import com.example.donttouchme.event.repository.TagRepository;
+import com.example.donttouchme.event.repository.TargetRepository;
+import com.example.donttouchme.excel.controller.dto.ImportExcelResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ExcelCommandService {
+
+    private final EventRepository eventRepository;
+    private final EventDetailRepository eventDetailRepository;
+    private final TargetRepository targetRepository;
+    private final TagRepository tagRepository;
+
+    public ImportExcelResponse importEventDetailsFromExcel(
+            final Long eventId,
+            final byte[] excelData
+    ) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 하는 event가 없습니다."));
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(excelData))) {
+            Sheet sheet = workbook.getSheetAt(0); // 첫 번째 시트 사용
+            EventInfo eventInfo = event.getEventInfo();
+
+            // 헤더 매핑 생성
+            Row headerRow = sheet.getRow(0);
+            Map<String, Integer> headerMap = createHeaderMap(headerRow, eventInfo);
+            List<EventDetail> eventDetails = new ArrayList<>();
+            // 데이터 행 처리
+            for (int i = 1; i <= sheet.getLastRowNum(); i++) {
+                Row row = sheet.getRow(i);
+                if (row == null) continue; // 빈 행은 건너뛰기
+
+                EventDetail eventDetail = buildEventDetailFromRow(row, headerMap, eventInfo, event);
+                eventDetails.add(eventDetailRepository.save(eventDetail));
+            }
+
+            return ImportExcelResponse.of(eventDetails);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("엑셀 파일 처리 실패", e);
+        }
+    }
+
+    private Map<String, Integer> createHeaderMap(
+            final Row headerRow,
+            final EventInfo eventInfo
+    ) {
+        Map<String, Integer> headerMap = new HashMap<>();
+        for (int i = 0; i < headerRow.getLastCellNum(); i++) {
+            String header = headerRow.getCell(i).getStringCellValue().trim();
+            if (eventInfo.isType() && "입출금 분류".equalsIgnoreCase(header)) headerMap.put("type", i);
+            if (eventInfo.isHistory() && "입출금 내역명".equalsIgnoreCase(header)) headerMap.put("history", i);
+            if (eventInfo.isPrice() && "금액".equalsIgnoreCase(header)) headerMap.put("price", i);
+            if (eventInfo.isName() && "이름".equalsIgnoreCase(header)) headerMap.put("name", i);
+            if (eventInfo.isTag() && "태그".equalsIgnoreCase(header)) headerMap.put("tags", i);
+            if (eventInfo.isSide() && "입금대상".equalsIgnoreCase(header)) headerMap.put("target", i); // Target을 Side로 매핑 가정
+        }
+        return headerMap;
+    }
+
+    private EventDetail buildEventDetailFromRow(Row row, Map<String, Integer> headerMap, EventInfo eventInfo, Event event) {
+        EventDetail.EventDetailBuilder builder = EventDetail.builder().event(event);
+
+        // 각 필드 설정
+        if (eventInfo.isType() && headerMap.containsKey("type")) {
+            builder.type(getCellValue(row, headerMap.get("type")));
+        }
+        if (eventInfo.isHistory() && headerMap.containsKey("history")) {
+            builder.history(getCellValue(row, headerMap.get("history")));
+        }
+        if (eventInfo.isPrice() && headerMap.containsKey("price")) {
+            builder.price(getCellValue(row, headerMap.get("price")));
+        }
+        if (eventInfo.isName() && headerMap.containsKey("name")) {
+            builder.name(getCellValue(row, headerMap.get("name")));
+        }
+        if (eventInfo.isTag() && headerMap.containsKey("tags")) {
+            String tagsValue = getCellValue(row, headerMap.get("tags"));
+            if (tagsValue != null && !tagsValue.isEmpty()) {
+                List<Tag> tags = Arrays.stream(tagsValue.split(","))
+                        .map(String::trim)
+                        .map(value -> Tag.builder().value(value).eventDetail(builder.build()).build()) // 임시 빌드 필요
+                        .toList();
+                // tags는 빌더로 바로 설정 불가, 이후 처리
+            }
+        }
+        if (eventInfo.isSide() && headerMap.containsKey("target")) {
+            String targetValue = getCellValue(row, headerMap.get("target"));
+            if (targetValue != null && !targetValue.isEmpty()) {
+                Target target = Target.builder().value(targetValue).build();
+                targetRepository.save(target);
+                builder.target(target);
+            }
+        }
+
+        EventDetail detail = builder.build();
+
+        // Tag는 EventDetail이 완성된 후 추가
+        if (eventInfo.isTag() && headerMap.containsKey("tags")) {
+            String tagsValue = getCellValue(row, headerMap.get("tags"));
+            if (tagsValue != null && !tagsValue.isEmpty()) {
+                List<Tag> tags = Arrays.stream(tagsValue.split(","))
+                        .map(String::trim)
+                        .map(value -> Tag.builder().value(value).eventDetail(detail).build())
+                        .toList();
+                detail.getTags().addAll(tags);
+            }
+        }
+
+        return detail;
+    }
+
+    private String getCellValue(Row row, Integer colIndex) {
+        Cell cell = row.getCell(colIndex);
+        if (cell == null) return null;
+        return switch (cell.getCellType()) {
+            case STRING -> cell.getStringCellValue();
+            case NUMERIC -> String.valueOf((int) cell.getNumericCellValue());
+            case BLANK -> null;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/example/donttouchme/excel/service/ExcelQueryService.java
+++ b/src/main/java/com/example/donttouchme/excel/service/ExcelQueryService.java
@@ -1,6 +1,9 @@
 package com.example.donttouchme.excel.service;
 
 import com.example.donttouchme.event.domain.Event;
+import com.example.donttouchme.event.domain.EventDetail;
+import com.example.donttouchme.event.domain.Tag;
+import com.example.donttouchme.event.domain.value.EventInfo;
 import com.example.donttouchme.event.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.Row;
@@ -32,15 +35,7 @@ public class ExcelQueryService {
                 XSSFWorkbook workbook = new XSSFWorkbook();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()
         ){
-            Sheet sheet = workbook.createSheet(event.getEventName());
-
-            List<String> cellValues = event.getEventInfo().toCellValues();
-
-            Row headerRow = sheet.createRow(0);
-
-            for(int i = 0; i < cellValues.size(); i++) {
-                headerRow.createCell(i).setCellValue(cellValues.get(i));
-            }
+            createHeader(event, workbook);
 
             workbook.write(out);
             return out.toByteArray();
@@ -48,5 +43,66 @@ public class ExcelQueryService {
         } catch (IOException e) {
             throw new IllegalArgumentException("엑셀양식 추출 실패");
         }
+    }
+
+    public byte[] exportEventToExcel(
+            final Long eventId
+    ) {
+        Event event = eventRepository.findById(eventId).orElseThrow(
+                () -> new IllegalArgumentException("해당 하는 event가 없습니다.")
+        );
+
+        try (
+                XSSFWorkbook workbook = new XSSFWorkbook();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()
+        ) {
+
+            Sheet sheet = createHeader(event, workbook);
+
+            List<EventDetail> eventDetails = event.getEventDetails();
+            EventInfo eventInfo = event.getEventInfo();
+            int rowNum = 1;
+
+            for (EventDetail detail : eventDetails) {
+                Row row = sheet.createRow(rowNum++);
+                int colNum = 0;
+
+                if (eventInfo.isType()) row.createCell(colNum++).setCellValue(detail.getType() != null ? detail.getType() : "");
+                if (eventInfo.isHistory()) row.createCell(colNum++).setCellValue(detail.getHistory() != null ? detail.getHistory() : "");
+                if (eventInfo.isPrice()) row.createCell(colNum++).setCellValue(detail.getPrice() != null ? detail.getPrice() : "");
+                if (eventInfo.isName()) row.createCell(colNum++).setCellValue(detail.getName() != null ? detail.getName() : "");
+                if (eventInfo.isTag()) row.createCell(colNum++).setCellValue(String.join(", ", detail.getTags().stream()
+                        .map(Tag::getValue).toList()));
+                if (eventInfo.isSide()) row.createCell(colNum++).setCellValue(detail.getTarget().getValue()!= null ? detail.getImage() : "");
+            }
+
+            for (int i = 0; i < sheet.getRow(0).getLastCellNum(); i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(out);
+            return out.toByteArray();
+
+
+        }catch (IOException e) {
+            throw new IllegalArgumentException("엑셀양식 추출 실패");
+        }
+    }
+
+    private Sheet createHeader(
+            final Event event,
+            final XSSFWorkbook workbook
+    ) {
+        Sheet sheet = workbook.createSheet(event.getEventName());
+
+        List<String> cellValues = event.getEventInfo().toCellValues();
+
+        Row headerRow = sheet.createRow(0);
+
+        for(int i = 0; i < cellValues.size(); i++) {
+            headerRow.createCell(i).setCellValue(cellValues.get(i));
+        }
+
+        return sheet;
     }
 }

--- a/src/main/java/com/example/donttouchme/excel/service/ExcelQueryService.java
+++ b/src/main/java/com/example/donttouchme/excel/service/ExcelQueryService.java
@@ -1,0 +1,52 @@
+package com.example.donttouchme.excel.service;
+
+import com.example.donttouchme.event.domain.Event;
+import com.example.donttouchme.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExcelQueryService {
+
+    private final EventRepository eventRepository;
+
+
+    public byte[] exportSampleExcel(
+            final Long eventId
+    ) {
+        Event event = eventRepository.findById(eventId).orElseThrow(
+                () -> new IllegalArgumentException("해당 하는 event가 없습니다.")
+        );
+
+        try (
+                XSSFWorkbook workbook = new XSSFWorkbook();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()
+        ){
+            Sheet sheet = workbook.createSheet(event.getEventName());
+
+            List<String> cellValues = event.getEventInfo().toCellValues();
+
+            Row headerRow = sheet.createRow(0);
+
+            for(int i = 0; i < cellValues.size(); i++) {
+                headerRow.createCell(i).setCellValue(cellValues.get(i));
+            }
+
+            workbook.write(out);
+            return out.toByteArray();
+
+        } catch (IOException e) {
+            throw new IllegalArgumentException("엑셀양식 추출 실패");
+        }
+    }
+}

--- a/src/main/java/com/example/donttouchme/mail/controller/MailController.java
+++ b/src/main/java/com/example/donttouchme/mail/controller/MailController.java
@@ -2,6 +2,8 @@ package com.example.donttouchme.mail.controller;
 
 import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeRequest;
 import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeResponse;
+import com.example.donttouchme.mail.controller.dto.EmailVerificationRequest;
+import com.example.donttouchme.mail.controller.dto.EmailVerificationResponse;
 import com.example.donttouchme.mail.service.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,4 +25,13 @@ public class MailController {
     ) {
         return ResponseEntity.ok(mailService.sendVerificationEmail(request));
     }
+
+    @PostMapping("/verify")
+    public ResponseEntity<EmailVerificationResponse> verifyEmailByCode(
+            @Validated @RequestBody final EmailVerificationRequest request
+    ) {
+        return ResponseEntity.ok(mailService.verifyEmailByCode(request));
+    }
+
+
 }

--- a/src/main/java/com/example/donttouchme/mail/controller/MailController.java
+++ b/src/main/java/com/example/donttouchme/mail/controller/MailController.java
@@ -16,9 +16,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/mail")
 @RequiredArgsConstructor
-public class MailController {
+public class MailController implements MailControllerSwagger{
     private final MailService mailService;
 
+    @Override
     @PostMapping("/send-verification")
     public ResponseEntity<EmailVerificationCodeResponse> sendVerificationEmail(
             @Validated @RequestBody final EmailVerificationCodeRequest request
@@ -26,6 +27,7 @@ public class MailController {
         return ResponseEntity.ok(mailService.sendVerificationEmail(request));
     }
 
+    @Override
     @PostMapping("/verify")
     public ResponseEntity<EmailVerificationResponse> verifyEmailByCode(
             @Validated @RequestBody final EmailVerificationRequest request

--- a/src/main/java/com/example/donttouchme/mail/controller/MailController.java
+++ b/src/main/java/com/example/donttouchme/mail/controller/MailController.java
@@ -1,0 +1,26 @@
+package com.example.donttouchme.mail.controller;
+
+import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeRequest;
+import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeResponse;
+import com.example.donttouchme.mail.service.MailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/mail")
+@RequiredArgsConstructor
+public class MailController {
+    private final MailService mailService;
+
+    @PostMapping("/send-verification")
+    public ResponseEntity<EmailVerificationCodeResponse> sendVerificationEmail(
+            @Validated @RequestBody final EmailVerificationCodeRequest request
+    ) {
+        return ResponseEntity.ok(mailService.sendVerificationEmail(request));
+    }
+}

--- a/src/main/java/com/example/donttouchme/mail/controller/MailControllerSwagger.java
+++ b/src/main/java/com/example/donttouchme/mail/controller/MailControllerSwagger.java
@@ -1,0 +1,29 @@
+package com.example.donttouchme.mail.controller;
+
+import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeRequest;
+import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeResponse;
+import com.example.donttouchme.mail.controller.dto.EmailVerificationRequest;
+import com.example.donttouchme.mail.controller.dto.EmailVerificationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "mail 관련 API", description = "mail 관련 API")
+public interface MailControllerSwagger {
+
+    @Operation(
+            summary = "이메일 인증코드 발송 API",
+            description = "이메일 인증 코드를 발송합니다."
+    )
+    ResponseEntity<EmailVerificationCodeResponse> sendVerificationEmail(
+            EmailVerificationCodeRequest emailVerificationCodeRequest
+    );
+
+    @Operation(
+            summary = "이메일 인증 API",
+            description = "발송 받은 코드로 이메일 인증 수행"
+    )
+    public ResponseEntity<EmailVerificationResponse> verifyEmailByCode(
+            EmailVerificationRequest emailVerificationRequest
+    );
+}

--- a/src/main/java/com/example/donttouchme/mail/controller/dto/EmailVerificationCodeRequest.java
+++ b/src/main/java/com/example/donttouchme/mail/controller/dto/EmailVerificationCodeRequest.java
@@ -1,0 +1,9 @@
+package com.example.donttouchme.mail.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailVerificationCodeRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        String email
+) {
+}

--- a/src/main/java/com/example/donttouchme/mail/controller/dto/EmailVerificationCodeResponse.java
+++ b/src/main/java/com/example/donttouchme/mail/controller/dto/EmailVerificationCodeResponse.java
@@ -1,0 +1,7 @@
+package com.example.donttouchme.mail.controller.dto;
+
+public record EmailVerificationCodeResponse(
+        String email,
+        String state
+) {
+}

--- a/src/main/java/com/example/donttouchme/mail/controller/dto/EmailVerificationRequest.java
+++ b/src/main/java/com/example/donttouchme/mail/controller/dto/EmailVerificationRequest.java
@@ -1,0 +1,13 @@
+package com.example.donttouchme.mail.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+public record EmailVerificationRequest(
+        @NotBlank(message = "이메일은 필수 입니다.")
+        String email,
+
+        @NotEmpty(message = "인증코드는 필수 입니다.")
+        String verificationCode
+) {
+}

--- a/src/main/java/com/example/donttouchme/mail/controller/dto/EmailVerificationResponse.java
+++ b/src/main/java/com/example/donttouchme/mail/controller/dto/EmailVerificationResponse.java
@@ -1,0 +1,7 @@
+package com.example.donttouchme.mail.controller.dto;
+
+public record EmailVerificationResponse(
+        String email,
+        String message
+) {
+}

--- a/src/main/java/com/example/donttouchme/mail/service/MailService.java
+++ b/src/main/java/com/example/donttouchme/mail/service/MailService.java
@@ -4,6 +4,10 @@ import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeRequest;
 import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeResponse;
 import com.example.donttouchme.mail.controller.dto.EmailVerificationRequest;
 import com.example.donttouchme.mail.controller.dto.EmailVerificationResponse;
+import com.example.donttouchme.member.controller.dto.TempPasswordIssueRequest;
+import com.example.donttouchme.member.controller.dto.TempPasswordIssueResponse;
+import com.example.donttouchme.member.domain.Member;
+import com.example.donttouchme.member.repository.MemberRepository;
 import com.example.donttouchme.member.service.MemberQueryService;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -14,6 +18,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
@@ -21,6 +26,8 @@ import org.thymeleaf.context.Context;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+
+import static com.example.donttouchme.member.domain.value.LoginProvider.original;
 
 @Service
 @Transactional
@@ -34,6 +41,10 @@ public class MailService {
     private final RedisTemplate<String, String> redisTemplate;
 
     private final MemberQueryService memberQueryService;
+
+    private final MemberRepository memberRepository;
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Value("${spring.data.redis.mailExTime}")
     private long CODE_EXPIRATION;
@@ -65,6 +76,33 @@ public class MailService {
             );
         }
         throw new IllegalArgumentException("인증에 싪패 했습니다.");
+    }
+
+    public TempPasswordIssueResponse issueTempPassword(
+            final TempPasswordIssueRequest request
+    ) {
+        Member member = memberQueryService.findMemberByEmailAndProvider(request.email(), original)
+                .orElseThrow(
+                        () -> new IllegalArgumentException("가입되지 않은 이메일입니다.")
+                );
+
+        redisTemplate.opsForValue().set(
+                "backup:pwd" + member.getId(),
+                member.getPassword(),
+                5, TimeUnit.MINUTES
+        );
+
+        String tempPassword = createTempPassword();
+
+        member.changePassword(bCryptPasswordEncoder.encode(tempPassword));
+        memberRepository.save(member);
+
+        sendTempPasswordEmailAsync(request.email(), tempPassword, member.getId());
+
+        return new TempPasswordIssueResponse(
+                request.email(),
+                "임시 비밀번호가 이메일로 전송 되었습니다."
+        );
     }
 
     private String createVerificationCode() {
@@ -107,6 +145,12 @@ public class MailService {
         }
     }
 
+    private String createTempPassword() {
+        return UUID.randomUUID()
+                .toString().substring(0, 10)
+                .toUpperCase();
+    }
+
 
     @Async("mailTaskExecutor") // 특정 스레드 풀 사용 (설정 안 하면 기본 풀 사용)
     public CompletableFuture<Void> sendEmailAsync(
@@ -125,10 +169,52 @@ public class MailService {
 
                 mailSender.send(message);
             } catch (MessagingException e) {
-                // 비동기 작업 내 예외 처리 (로깅 추천)
                 throw new IllegalStateException("비동기 메일 전송 실패: " + email, e);
             }
         });
+    }
+
+    private String createTempPasswordContext(final String email, final String tempPassword) {
+        Context context = new Context();
+        context.setVariable("recipientName", email != null ? email : "고객님");
+        context.setVariable("temporaryPassword", tempPassword);
+        return templateEngine.process("temporaryPassword", context);
+    }
+
+    @Async("mailTaskExecutor")
+    public CompletableFuture<Void> sendTempPasswordEmailAsync(
+            final String email,
+            final String tempPassword,
+            final Long memberId
+    ) {
+        return CompletableFuture.runAsync(() -> {
+            String context = createTempPasswordContext(email, tempPassword);
+            try {
+                MimeMessage message = mailSender.createMimeMessage();
+                MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+                helper.setTo(email);
+                helper.setSubject("dontTouchMe 임시 비밀번호");
+                helper.setText(context, true);
+                helper.setFrom("your-email@gmail.com");
+
+                mailSender.send(message);
+            } catch (MessagingException e) {
+                rollbackPassword(memberId);
+                throw new IllegalStateException("임시 비밀번호 메일 전송 실패: " + email, e);
+            }
+        });
+    }
+
+    @Transactional
+    public void rollbackPassword(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalStateException("회원을 찾을 수 없습니다."));
+        String originalPassword = redisTemplate.opsForValue().get("backup:pwd:" + memberId);
+        if (originalPassword != null) {
+            member.changePassword(originalPassword);
+            memberRepository.save(member);
+            redisTemplate.delete("backup:pwd:" + memberId);
+        }
     }
 
 }

--- a/src/main/java/com/example/donttouchme/mail/service/MailService.java
+++ b/src/main/java/com/example/donttouchme/mail/service/MailService.java
@@ -1,0 +1,92 @@
+package com.example.donttouchme.mail.service;
+
+import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeRequest;
+import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeResponse;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    private final TemplateEngine templateEngine;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${spring.data.redis.mailExTime}")
+    private long CODE_EXPIRATION;
+
+    public EmailVerificationCodeResponse sendVerificationEmail(
+            final EmailVerificationCodeRequest request
+    ) {
+        String verificationCode = createVerificationCode();
+
+        redisTemplate.opsForValue().set(request.email() ,verificationCode, CODE_EXPIRATION, TimeUnit.MINUTES);
+
+        sendEmailAsync(request.email(), verificationCode);
+
+        return new EmailVerificationCodeResponse(
+                request.email(),
+                "인증메일이 전송 요청되었습니다."
+        );
+    }
+
+    private String createVerificationCode() {
+        return UUID.randomUUID()
+                .toString().substring(0, 6)
+                .toUpperCase();
+    }
+
+    private String createContext(
+            final String email,
+            final String verificationCode
+    ) {
+        Context context = new Context();
+        context.setVariable("recipientName", email != null ? email : "고객님");
+        context.setVariable("verificationCode", verificationCode);
+        return templateEngine.process("emailVerification", context);
+    }
+
+
+    @Async("mailTaskExecutor") // 특정 스레드 풀 사용 (설정 안 하면 기본 풀 사용)
+    public CompletableFuture<Void> sendEmailAsync(
+            final String email,
+            final String verificationCode
+    ) {
+        return CompletableFuture.runAsync(() -> {
+            String context = createContext(email, verificationCode);
+            try {
+                MimeMessage message = mailSender.createMimeMessage();
+                MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+                helper.setTo(email);
+                helper.setSubject("dontTouchMe 이메일 인증 코드");
+                helper.setText(context, true);
+                helper.setFrom("your-email@gmail.com");
+
+                mailSender.send(message);
+            } catch (MessagingException e) {
+                // 비동기 작업 내 예외 처리 (로깅 추천)
+                throw new IllegalStateException("비동기 메일 전송 실패: " + email, e);
+            }
+        });
+    }
+
+}
+

--- a/src/main/java/com/example/donttouchme/member/controller/MemberController.java
+++ b/src/main/java/com/example/donttouchme/member/controller/MemberController.java
@@ -1,7 +1,9 @@
 package com.example.donttouchme.member.controller;
 
+import com.example.donttouchme.common.config.security.AuthMember;
 import com.example.donttouchme.mail.service.MailService;
 import com.example.donttouchme.member.controller.dto.*;
+import com.example.donttouchme.member.domain.Member;
 import com.example.donttouchme.member.service.MemberCommandService;
 import com.example.donttouchme.member.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
@@ -40,9 +42,20 @@ public class MemberController implements MemberControllerSwagger{
 
     @Override
     @PostMapping("/issue-temp-password")
-    public ResponseEntity<TempPasswordIssueResponse> issueTempPassword(TempPasswordIssueRequest request) {
+    public ResponseEntity<TempPasswordIssueResponse> issueTempPassword(
+            final TempPasswordIssueRequest request
+    ) {
         return ResponseEntity.ok(
                 mailService.issueTempPassword(request)
         );
+    }
+
+    @Override
+    @PatchMapping("/password")
+    public ResponseEntity<ChangePasswordResponse> changePassword(
+            @AuthMember Member member,
+            final ChangePasswordRequest request
+    ) {
+        return ResponseEntity.ok(memberCommandService.changePassword(member, request));
     }
 }

--- a/src/main/java/com/example/donttouchme/member/controller/MemberController.java
+++ b/src/main/java/com/example/donttouchme/member/controller/MemberController.java
@@ -1,8 +1,7 @@
 package com.example.donttouchme.member.controller;
 
-import com.example.donttouchme.member.controller.dto.CheckDuplicateEmailResponse;
-import com.example.donttouchme.member.controller.dto.MemberSignUpRequest;
-import com.example.donttouchme.member.controller.dto.MemberSignUpResponse;
+import com.example.donttouchme.mail.service.MailService;
+import com.example.donttouchme.member.controller.dto.*;
 import com.example.donttouchme.member.service.MemberCommandService;
 import com.example.donttouchme.member.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +16,7 @@ public class MemberController implements MemberControllerSwagger{
 
     private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
+    private final MailService mailService;
 
     @Override
     @GetMapping("/check-email-duplicate")
@@ -38,4 +38,11 @@ public class MemberController implements MemberControllerSwagger{
         );
     }
 
+    @Override
+    @PostMapping("/issue-temp-password")
+    public ResponseEntity<TempPasswordIssueResponse> issueTempPassword(TempPasswordIssueRequest request) {
+        return ResponseEntity.ok(
+                mailService.issueTempPassword(request)
+        );
+    }
 }

--- a/src/main/java/com/example/donttouchme/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/example/donttouchme/member/controller/MemberControllerSwagger.java
@@ -1,6 +1,7 @@
 package com.example.donttouchme.member.controller;
 
 import com.example.donttouchme.member.controller.dto.*;
+import com.example.donttouchme.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -30,5 +31,14 @@ public interface MemberControllerSwagger {
     )
     ResponseEntity<TempPasswordIssueResponse> issueTempPassword(
             TempPasswordIssueRequest request
+    );
+
+    @Operation(
+            summary = "비밀 번호 변경 API",
+            description = "비밀 번호를 변경합니다."
+    )
+    ResponseEntity<ChangePasswordResponse> changePassword(
+            Member member,
+            ChangePasswordRequest request
     );
 }

--- a/src/main/java/com/example/donttouchme/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/com/example/donttouchme/member/controller/MemberControllerSwagger.java
@@ -1,8 +1,6 @@
 package com.example.donttouchme.member.controller;
 
-import com.example.donttouchme.member.controller.dto.CheckDuplicateEmailResponse;
-import com.example.donttouchme.member.controller.dto.MemberSignUpRequest;
-import com.example.donttouchme.member.controller.dto.MemberSignUpResponse;
+import com.example.donttouchme.member.controller.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +12,7 @@ public interface MemberControllerSwagger {
             summary = "이메일 중복확인 API",
             description = "이메일 중복확인 API"
     )
-    public ResponseEntity<CheckDuplicateEmailResponse> checkDuplicateEmail(
+    ResponseEntity<CheckDuplicateEmailResponse> checkDuplicateEmail(
             String email
     );
 
@@ -22,7 +20,15 @@ public interface MemberControllerSwagger {
             summary = "회원가입 API",
             description = "회원가입 API"
     )
-    public ResponseEntity<MemberSignUpResponse> signUp(
+     ResponseEntity<MemberSignUpResponse> signUp(
             final MemberSignUpRequest request
+    );
+
+    @Operation(
+            summary = "임시 비빌번호 발급 API",
+            description = "임시 비밀번호를 발급한다."
+    )
+    ResponseEntity<TempPasswordIssueResponse> issueTempPassword(
+            TempPasswordIssueRequest request
     );
 }

--- a/src/main/java/com/example/donttouchme/member/controller/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/example/donttouchme/member/controller/dto/ChangePasswordRequest.java
@@ -1,0 +1,6 @@
+package com.example.donttouchme.member.controller.dto;
+
+public record ChangePasswordRequest(
+        String newPassword
+) {
+}

--- a/src/main/java/com/example/donttouchme/member/controller/dto/ChangePasswordResponse.java
+++ b/src/main/java/com/example/donttouchme/member/controller/dto/ChangePasswordResponse.java
@@ -1,0 +1,9 @@
+package com.example.donttouchme.member.controller.dto;
+
+public record ChangePasswordResponse(
+        String message
+) {
+        public static ChangePasswordResponse addMessage(final String message) {
+            return new ChangePasswordResponse(message);
+        }
+}

--- a/src/main/java/com/example/donttouchme/member/controller/dto/TempPasswordIssueRequest.java
+++ b/src/main/java/com/example/donttouchme/member/controller/dto/TempPasswordIssueRequest.java
@@ -1,0 +1,6 @@
+package com.example.donttouchme.member.controller.dto;
+
+public record TempPasswordIssueRequest(
+        String email
+) {
+}

--- a/src/main/java/com/example/donttouchme/member/controller/dto/TempPasswordIssueResponse.java
+++ b/src/main/java/com/example/donttouchme/member/controller/dto/TempPasswordIssueResponse.java
@@ -1,0 +1,7 @@
+package com.example.donttouchme.member.controller.dto;
+
+public record TempPasswordIssueResponse(
+        String email,
+        String message
+) {
+}

--- a/src/main/java/com/example/donttouchme/member/domain/Member.java
+++ b/src/main/java/com/example/donttouchme/member/domain/Member.java
@@ -64,4 +64,8 @@ public class Member extends BaseEntity {
         this.loginProvider = loginProvider;
         this.contact = contact;
     }
+
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/com/example/donttouchme/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/donttouchme/member/service/MemberCommandService.java
@@ -73,8 +73,12 @@ public class MemberCommandService {
         member.changePassword(
                 bCryptPasswordEncoder.encode(request.newPassword())
         );
+        try {
+            memberRepository.save(member);
+        }catch (Exception e) {
+            throw new IllegalArgumentException("member 저장실패");
+        }
 
-        memberRepository.save(member);
 
         return ChangePasswordResponse.addMessage("비빌번호 변경 성공");
     }

--- a/src/main/java/com/example/donttouchme/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/donttouchme/member/service/MemberCommandService.java
@@ -1,5 +1,7 @@
 package com.example.donttouchme.member.service;
 
+import com.example.donttouchme.member.controller.dto.ChangePasswordRequest;
+import com.example.donttouchme.member.controller.dto.ChangePasswordResponse;
 import com.example.donttouchme.member.controller.dto.MemberSignUpRequest;
 import com.example.donttouchme.member.domain.Member;
 import com.example.donttouchme.member.domain.value.LoginProvider;
@@ -62,5 +64,18 @@ public class MemberCommandService {
             throw new IllegalArgumentException("회원 생성 실패");
         }
 
+    }
+
+    public ChangePasswordResponse changePassword(
+            final Member member,
+            final ChangePasswordRequest request
+    ) {
+        member.changePassword(
+                bCryptPasswordEncoder.encode(request.newPassword())
+        );
+
+        memberRepository.save(member);
+
+        return ChangePasswordResponse.addMessage("비빌번호 변경 성공");
     }
 }

--- a/src/main/resources/templates/emailVerification.html
+++ b/src/main/resources/templates/emailVerification.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Email Verification</title>
+</head>
+<body>
+<h3>이메일 인증 코드</h3>
+<p>안녕하세요, <span th:text="${recipientName}">고객님</span>!</p>
+<p>아래 인증 코드를 입력하여 이메일 인증을 완료해주세요:</p>
+<h2 style="color: #2e6c80;" th:text="${verificationCode}">123456</h2>
+<p>이 코드는 발송 시점부터 5분간 유효합니다.</p>
+<p>감사합니다!<br/>don Touch ME Team</p>
+</body>
+</html>

--- a/src/main/resources/templates/temporaryPassword.html
+++ b/src/main/resources/templates/temporaryPassword.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Temporary Password</title>
+</head>
+<body>
+<h3>임시 비밀번호 발급</h3>
+<p>안녕하세요, <span th:text="${recipientName}">고객님</span>!</p>
+<p>아래 임시 비밀번호를 사용하여 로그인 후, 새로운 비밀번호로 변경해주세요:</p>
+<h2 style="color: #2e6c80;" th:text="${temporaryPassword}">TEMP1234</h2>
+<p>이 임시 비밀번호는 발송 시점부터 30분간 유효합니다.</p>
+<p>보안을 위해 로그인 후 즉시 비밀번호를 변경하시기 바랍니다.</p>
+<p>감사합니다!<br/>don Touch ME Team</p>
+</body>
+</html>

--- a/src/test/java/com/example/donttouchme/excel/integration/ExcelQueryServiceTest.java
+++ b/src/test/java/com/example/donttouchme/excel/integration/ExcelQueryServiceTest.java
@@ -1,7 +1,9 @@
 package com.example.donttouchme.excel.integration;
 
-import com.example.donttouchme.event.domain.Event;
+import com.example.donttouchme.event.domain.*;
+import com.example.donttouchme.event.repository.EventDetailRepository;
 import com.example.donttouchme.event.repository.EventRepository;
+import com.example.donttouchme.event.repository.TagRepository;
 import com.example.donttouchme.excel.service.ExcelQueryService;
 import com.example.donttouchme.member.domain.Member;
 import com.example.donttouchme.member.repository.MemberRepository;
@@ -25,6 +27,12 @@ class ExcelQueryServiceTest extends IntegrationTestSupport {
     @Autowired
     EventRepository eventRepository;
 
+    @Autowired
+    EventDetailRepository eventDetailRepository;
+
+    @Autowired
+    TagRepository tagRepository;
+
     @Test
     @DisplayName("엑셀양식 생성 성공")
     void exportSampleExcelSuccess() {
@@ -35,6 +43,25 @@ class ExcelQueryServiceTest extends IntegrationTestSupport {
 
         //when
         byte[] bytes = excelQueryService.exportSampleExcel(event.getId());
+
+        //then
+        assertThat(bytes).isNotNull();
+    }
+
+    @Test
+    @DisplayName("엑셀로 추출 성공")
+    void exportToExcelSuccess() {
+
+        //given
+        Member member = memberRepository.save(createTestMember());
+        Event event = eventRepository.save(createTestEvent(member));
+        Target target = createTestTarget();
+        SendValue sendValue = createTestSendValue();
+        EventDetail eventDetail = eventDetailRepository.save(createTestEventDetail(event, target, sendValue));
+        Tag tag = tagRepository.save(createTestTag(eventDetail));
+
+        //then
+        byte[] bytes = excelQueryService.exportEventToExcel(event.getId());
 
         //then
         assertThat(bytes).isNotNull();

--- a/src/test/java/com/example/donttouchme/excel/integration/ExcelQueryServiceTest.java
+++ b/src/test/java/com/example/donttouchme/excel/integration/ExcelQueryServiceTest.java
@@ -6,12 +6,14 @@ import com.example.donttouchme.excel.service.ExcelQueryService;
 import com.example.donttouchme.member.domain.Member;
 import com.example.donttouchme.member.repository.MemberRepository;
 import com.example.donttouchme.support.IntegrationTestSupport;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Transactional
 class ExcelQueryServiceTest extends IntegrationTestSupport {
 
     @Autowired

--- a/src/test/java/com/example/donttouchme/excel/integration/ExcelQueryServiceTest.java
+++ b/src/test/java/com/example/donttouchme/excel/integration/ExcelQueryServiceTest.java
@@ -1,0 +1,40 @@
+package com.example.donttouchme.excel.integration;
+
+import com.example.donttouchme.event.domain.Event;
+import com.example.donttouchme.event.repository.EventRepository;
+import com.example.donttouchme.excel.service.ExcelQueryService;
+import com.example.donttouchme.member.domain.Member;
+import com.example.donttouchme.member.repository.MemberRepository;
+import com.example.donttouchme.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExcelQueryServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    ExcelQueryService excelQueryService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    EventRepository eventRepository;
+
+    @Test
+    @DisplayName("엑셀양식 생성 성공")
+    void exportSampleExcelSuccess() {
+
+        //given
+        Member member = memberRepository.save(createTestMember());
+        Event event = eventRepository.save(createTestEvent(member));
+
+        //when
+        byte[] bytes = excelQueryService.exportSampleExcel(event.getId());
+
+        //then
+        assertThat(bytes).isNotNull();
+    }
+}

--- a/src/test/java/com/example/donttouchme/mail/mock/MailServiceTest.java
+++ b/src/test/java/com/example/donttouchme/mail/mock/MailServiceTest.java
@@ -1,0 +1,173 @@
+package com.example.donttouchme.mail.mock;
+
+import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeRequest;
+import com.example.donttouchme.mail.controller.dto.EmailVerificationCodeResponse;
+import com.example.donttouchme.mail.controller.dto.EmailVerificationRequest;
+import com.example.donttouchme.mail.controller.dto.EmailVerificationResponse;
+import com.example.donttouchme.mail.service.MailService;
+import com.example.donttouchme.member.service.MemberQueryService;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@EnableAsync
+class MailServiceTest {
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private MemberQueryService memberQueryService;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private MailService mailService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(mailService, "CODE_EXPIRATION", 5L);
+    }
+
+    @Test
+    void sendVerificationEmail_성공적으로_인증메일_전송_요청() throws Exception {
+        // Given
+        EmailVerificationCodeRequest request = new EmailVerificationCodeRequest("test@example.com");
+        when(memberQueryService.checkDuplicateEmail(request.email())).thenReturn(false);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(templateEngine.process(eq("emailVerification"), any(Context.class))).thenReturn("<html>mocked</html>");
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // When
+        EmailVerificationCodeResponse response = mailService.sendVerificationEmail(request);
+
+        // Then
+        assertThat(response.email()).isEqualTo(request.email());
+        assertThat(response.state()).isEqualTo("인증메일이 전송 요청되었습니다.");
+        verify(valueOperations).set(eq(request.email()), anyString(), eq(5L), eq(TimeUnit.MINUTES));
+    }
+
+    @Test
+    void sendVerificationEmail_중복된_이메일이면_예외_발생() {
+        // Given
+        EmailVerificationCodeRequest request = new EmailVerificationCodeRequest("test@example.com");
+        when(memberQueryService.checkDuplicateEmail(request.email())).thenReturn(true);
+
+        // When & Then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            mailService.sendVerificationEmail(request);
+        });
+        assertThat(exception.getMessage()).isEqualTo("이미 가입한 Email 입니다.");
+        verify(redisTemplate, never()).opsForValue();
+    }
+
+    @Test
+    void verifyEmailByCode_유효한_코드로_인증_성공() {
+        // Given
+        EmailVerificationRequest request = new EmailVerificationRequest("test@example.com", "ABC123");
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("test@example.com")).thenReturn("ABC123");
+
+        // When
+        EmailVerificationResponse response = mailService.verifyEmailByCode(request);
+
+        // Then
+        assertThat(response.email()).isEqualTo(request.email());
+        assertThat(response.message()).isEqualTo("인증이 완료 되었습니다.");
+        verify(redisTemplate).delete("test@example.com");
+    }
+
+    @Test
+    void verifyEmailByCode_잘못된_코드로_인증_실패() {
+        // Given
+        EmailVerificationRequest request = new EmailVerificationRequest("test@example.com", "WRONG");
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("test@example.com")).thenReturn("ABC123");
+
+        // When & Then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            mailService.verifyEmailByCode(request);
+        });
+        assertThat(exception.getMessage()).isEqualTo("인증에 싪패 했습니다.");
+        verify(redisTemplate, never()).delete(anyString());
+    }
+
+    @Test
+    void verifyEmailByCode_만료된_코드로_인증_실패() {
+        // Given
+        EmailVerificationRequest request = new EmailVerificationRequest("test@example.com", "ABC123");
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("test@example.com")).thenReturn(null);
+
+        // When & Then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            mailService.verifyEmailByCode(request);
+        });
+        assertThat(exception.getMessage()).isEqualTo("인증에 싪패 했습니다.");
+        verify(redisTemplate, never()).delete(anyString());
+    }
+
+    @Test
+    void sendEmailAsync_비동기_메일_전송_성공() throws Exception {
+        // Given
+        String email = "test@example.com";
+        String verificationCode = "ABC123";
+        when(templateEngine.process(eq("emailVerification"), any(Context.class))).thenReturn("<html>mocked</html>");
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // When
+        CompletableFuture<Void> future = mailService.sendEmailAsync(email, verificationCode);
+
+        // Then
+        future.get(2, TimeUnit.SECONDS); // 비동기 작업 완료 대기
+        verify(mailSender).send(mimeMessage);
+    }
+
+    @Test
+    void sendEmailAsync_메일_전송_실패_시_예외_발생() {
+        // Given
+        String email = "test@example.com";
+        String verificationCode = "ABC123";
+        when(templateEngine.process(eq("emailVerification"), any(Context.class))).thenReturn("<html>mocked</html>");
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+        // MessagingException 대신 RuntimeException으로 변경
+        doThrow(new RuntimeException("Mail server error")).when(mailSender).send(mimeMessage);
+
+        // When
+        CompletableFuture<Void> future = mailService.sendEmailAsync(email, verificationCode);
+
+        // Then
+        assertThrows(ExecutionException.class, () -> future.get(2, TimeUnit.SECONDS));
+    }
+}

--- a/src/test/java/com/example/donttouchme/member/domain/MemberTest.java
+++ b/src/test/java/com/example/donttouchme/member/domain/MemberTest.java
@@ -1,0 +1,24 @@
+package com.example.donttouchme.member.domain;
+
+import com.example.donttouchme.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemberTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("member password 변경 테스트")
+    void passwordChangeTest() {
+
+        //given
+        Member testMember = createTestMember();
+
+        //when
+        testMember.changePassword("1234");
+
+        //then
+        assertThat(testMember.getPassword()).isEqualTo("1234");
+    }
+}

--- a/src/test/java/com/example/donttouchme/member/integration/MemberCommandServiceTest.java
+++ b/src/test/java/com/example/donttouchme/member/integration/MemberCommandServiceTest.java
@@ -1,9 +1,11 @@
 package com.example.donttouchme.member.integration;
 
+import com.example.donttouchme.member.controller.dto.ChangePasswordRequest;
 import com.example.donttouchme.member.controller.dto.MemberSignUpRequest;
 import com.example.donttouchme.member.domain.Member;
 import com.example.donttouchme.member.domain.value.LoginProvider;
 import com.example.donttouchme.member.domain.value.ROLE;
+import com.example.donttouchme.member.repository.MemberRepository;
 import com.example.donttouchme.member.service.MemberCommandService;
 import com.example.donttouchme.member.service.dto.CreateMemberDto;
 import com.example.donttouchme.support.IntegrationTestSupport;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,6 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MemberCommandServiceTest extends IntegrationTestSupport {
     @Autowired
     MemberCommandService memberCommandService;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Test
     @DisplayName("OAuth2 member 정상 생성")
@@ -117,6 +124,40 @@ class MemberCommandServiceTest extends IntegrationTestSupport {
         //then
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             memberCommandService.signUp(memberSignUpRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 성공")
+    void changePasswordSuccess() {
+        // given
+        Member testMember = createTestMember();
+        Member save = memberRepository.save(testMember);
+        String originalPassword = save.getPassword();
+        // when
+        memberCommandService.changePassword(
+                save,
+                new ChangePasswordRequest("zzzzz")
+        );
+
+        // then
+        assertThat(save.getPassword()).isNotEqualTo(originalPassword);
+    }
+
+    @Test
+    @DisplayName("비빌번호 변경 예외")
+    void changePasswordFail() {
+        //given
+        Member testMember = createTestMember();
+        Member save = memberRepository.save(testMember);
+
+        //when
+        //then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            memberCommandService.changePassword(
+                    save,
+                    new ChangePasswordRequest(null)
+            );
         });
     }
 

--- a/src/test/java/com/example/donttouchme/member/integration/MemberCommandServiceTest.java
+++ b/src/test/java/com/example/donttouchme/member/integration/MemberCommandServiceTest.java
@@ -25,6 +25,8 @@ class MemberCommandServiceTest extends IntegrationTestSupport {
     @Test
     @DisplayName("OAuth2 member 정상 생성")
     void OAuth2memberCreateSuccess() {
+
+        //given
         CreateMemberDto createMemberDto = new CreateMemberDto(
                 "test",
                 "test@test.com",
@@ -32,14 +34,18 @@ class MemberCommandServiceTest extends IntegrationTestSupport {
                 LoginProvider.original
         );
 
+        //when
         Member member = memberCommandService.createMember(createMemberDto);
 
+        //then
         assertThat(member).isNotNull();
     }
 
     @Test
     @DisplayName("OAuth2 member 생성 실패")
     void OAuth2memberCreateFail() {
+
+        //given
         CreateMemberDto createMemberDto = new CreateMemberDto(
                 null,
                 "test@test.com",
@@ -47,6 +53,8 @@ class MemberCommandServiceTest extends IntegrationTestSupport {
                 LoginProvider.google
         );
 
+        //when
+        //then
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             memberCommandService.createMember(createMemberDto);
         });
@@ -55,6 +63,8 @@ class MemberCommandServiceTest extends IntegrationTestSupport {
     @Test
     @DisplayName("original member 생성 성공")
     void originalMemberCreateSuccess() {
+
+        //given
         MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(
                 "test",
                 "test@Test.com",
@@ -62,15 +72,18 @@ class MemberCommandServiceTest extends IntegrationTestSupport {
                 "test"
         );
 
-
+        //when
         Member member = memberCommandService.signUp(memberSignUpRequest);
 
+        //then
         assertThat(member).isNotNull();
     }
 
     @Test
     @DisplayName("original member 생성 실패")
     void originalMemberCreateFail() {
+
+        //given
         MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(
                 null,
                 "test@Test.com",
@@ -79,6 +92,8 @@ class MemberCommandServiceTest extends IntegrationTestSupport {
         );
 
 
+        //when
+        //then
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             memberCommandService.signUp(memberSignUpRequest);
         });
@@ -87,6 +102,8 @@ class MemberCommandServiceTest extends IntegrationTestSupport {
     @Test
     @DisplayName("이메일 중복 검사 실패로 member 생성실패")
     void memberCreateFailedByDuplicate() {
+
+        //given
         MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(
                 "test",
                 "test@Test.com",
@@ -95,6 +112,9 @@ class MemberCommandServiceTest extends IntegrationTestSupport {
         );
         Member member = memberCommandService.signUp(memberSignUpRequest);
 
+
+        //when
+        //then
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             memberCommandService.signUp(memberSignUpRequest);
         });

--- a/src/test/java/com/example/donttouchme/support/IntegrationTestSupport.java
+++ b/src/test/java/com/example/donttouchme/support/IntegrationTestSupport.java
@@ -1,7 +1,7 @@
 package com.example.donttouchme.support;
 
 
-import com.example.donttouchme.event.domain.Event;
+import com.example.donttouchme.event.domain.*;
 import com.example.donttouchme.event.domain.value.EventInfo;
 import com.example.donttouchme.event.domain.value.Location;
 import com.example.donttouchme.member.domain.Member;
@@ -56,6 +56,41 @@ public abstract class IntegrationTestSupport {
                                 .build()
                 )
                 .member(member)
+                .build();
+    }
+
+    protected EventDetail createTestEventDetail(
+            Event event,
+            Target target,
+            SendValue sendValue
+    ){
+        return EventDetail.builder()
+                .price(String.valueOf(1234))
+                .event(event)
+                .history("sdfsd")
+                .image("image")
+                .type("type")
+                .target(target)
+                .sendValue(sendValue)
+                .name("name")
+                .build();
+    }
+
+    protected Target createTestTarget(){
+        return Target.builder()
+                .value("target")
+                .build();
+    }
+    protected SendValue createTestSendValue(){
+        return SendValue.builder()
+                .value("sendValue")
+                .build();
+    }
+
+    protected Tag createTestTag(EventDetail eventDetail){
+        return Tag.builder()
+                .eventDetail(eventDetail)
+                .value("Tag")
                 .build();
     }
 

--- a/src/test/java/com/example/donttouchme/support/IntegrationTestSupport.java
+++ b/src/test/java/com/example/donttouchme/support/IntegrationTestSupport.java
@@ -1,12 +1,18 @@
 package com.example.donttouchme.support;
 
 
+import com.example.donttouchme.event.domain.Event;
+import com.example.donttouchme.event.domain.value.EventInfo;
+import com.example.donttouchme.event.domain.value.Location;
 import com.example.donttouchme.member.domain.Member;
 import com.example.donttouchme.member.domain.value.LoginProvider;
 import com.example.donttouchme.member.domain.value.ROLE;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -22,6 +28,35 @@ public abstract class IntegrationTestSupport {
                 .contact("010-1234-5678")
                 .password("test")
                 .builderWithPassword();
+    }
+
+    protected Event createTestEvent(Member member){
+        return Event.builder()
+                .eventInfo(
+                        EventInfo.builder()
+                                .isType(true)
+                                .isTag(true)
+                                .isSide(true)
+                                .isHistory(true)
+                                .isImage(true)
+                                .isName(true)
+                                .isPrice(true)
+                                .isSend(true)
+                                .build()
+                )
+                .eventDate(LocalDate.now())
+                .eventName("test")
+                .eventType("test")
+                .participants(100)
+                .location(
+                        Location.builder()
+                                .address("test")
+                                .latitude(new BigDecimal(123))
+                                .longitude(new BigDecimal(456))
+                                .build()
+                )
+                .member(member)
+                .build();
     }
 
 }

--- a/src/test/resources/templates/emailVerification.html
+++ b/src/test/resources/templates/emailVerification.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Email Verification</title>
+</head>
+<body>
+<h3>이메일 인증 코드</h3>
+<p>안녕하세요, <span th:text="${recipientName}">고객님</span>!</p>
+<p>아래 인증 코드를 입력하여 이메일 인증을 완료해주세요:</p>
+<h2 style="color: #2e6c80;" th:text="${verificationCode}">123456</h2>
+<p>이 코드는 발송 시점부터 5분간 유효합니다.</p>
+<p>감사합니다!<br/>don Touch ME Team</p>
+</body>
+</html>


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #29 

### 구현 내용 📢
이메일 인증번호 전송

엑셀 양식 다운로드

엑셀 업로드

엑셀로 추출


### 테스트 결과 🧩
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

![image](https://github.com/user-attachments/assets/84708645-6c67-4588-9f0f-f64ad654395c)



### 리뷰 포인트 📌
