### PR TITLE
fix: 회원 수정 기능 password null 처리

### DIFF
--- a/src/main/java/com/example/donttouchme/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/donttouchme/member/service/MemberCommandService.java
@@ -100,7 +100,13 @@ public class MemberCommandService {
             throw new IllegalArgumentException("테스트 계정은 수정할 수 없습니다.");
         }
 
-        member.modifyMember(request, bCryptPasswordEncoder.encode(request.newPassword()));
+        if (request.newPassword() != null && !request.newPassword().isBlank()) {
+            String encodedPassword = bCryptPasswordEncoder.encode(request.newPassword());
+            member.modifyMember(request, encodedPassword);
+        } else {
+            throw new IllegalArgumentException("빈 패스워드로는 변경할 수 없습니다.");
+        }
+
         try {
             memberRepository.save(member);
         } catch (Exception e) {


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #86 

### 구현 내용 📢
회원 수정 기능 password null 처리

### 테스트 결과 🧩

### 리뷰 포인트 📌
